### PR TITLE
chore(fragment): Switched to new version of tessellate-request

### DIFF
--- a/packages/tessellate-fragment/package.json
+++ b/packages/tessellate-fragment/package.json
@@ -38,7 +38,7 @@
     "request": "2.79.0",
     "request-promise-native": "1.0.3",
     "tessellate-render": "0.1.0",
-    "tessellate-request": "1.0.0"
+    "tessellate-request": "1.1.0"
   },
   "devDependencies": {
     "babel-cli": "6.18.0",


### PR DESCRIPTION
affects: tessellate-fragment

New version is needed in order to use content service with OAuth 2.