### PR TITLE
fix(fragment): Fixed x-zalando-request-uri parsing

### DIFF
--- a/packages/tessellate-fragment/src/actions/sources-resolver.js
+++ b/packages/tessellate-fragment/src/actions/sources-resolver.js
@@ -17,9 +17,14 @@ const SOURCES_QUERY_PARAM = 'sources'
 const SOURCES_PROPERTY_BY_HEADER_KEY = {
   'x-zalando-request-uri': {
     key: 'bundles:path',
-    transformValue: (value) => {
-      const {hostname, pathname} = url.parse(value)
-      return path.join(hostname.replace(/^www\./, ''), pathname)
+    transformValue: (value, headers) => {
+      const { pathname } = url.parse(value)
+      const hostname = headers['x-zalando-request-host']
+      if (hostname) {
+        return path.join(hostname.replace(/^www\./, ''), pathname)
+      } else {
+        return pathname
+      }
     }
   }
 }
@@ -61,7 +66,7 @@ function assignSourcePropertiesFromHeaders(headers: Object, sources: Object) {
         target = target[key]
       }
       const lastKey = keys.shift()
-      target[lastKey] = SOURCES_PROPERTY_BY_HEADER_KEY[headerName].transformValue(headers[headerName])
+      target[lastKey] = SOURCES_PROPERTY_BY_HEADER_KEY[headerName].transformValue(headers[headerName], headers)
     }
   }
 }

--- a/packages/tessellate-fragment/src/actions/sources-resolver.js
+++ b/packages/tessellate-fragment/src/actions/sources-resolver.js
@@ -20,11 +20,7 @@ const SOURCES_PROPERTY_BY_HEADER_KEY = {
     transformValue: (value, headers) => {
       const { pathname } = url.parse(value)
       const hostname = headers['x-zalando-request-host']
-      if (hostname) {
-        return path.join(hostname.replace(/^www\./, ''), pathname)
-      } else {
-        return pathname
-      }
+      return path.join(hostname.replace(/^www\./, ''), pathname)
     }
   }
 }

--- a/packages/tessellate-fragment/test/actions/sources-resolver.test.js
+++ b/packages/tessellate-fragment/test/actions/sources-resolver.test.js
@@ -12,8 +12,20 @@ describe('sources-resolver', () => {
     expect(sources.bundles.src).toBe('http://localhost:3001')
   })
 
-  it('merges header properties with properties from nconf', async () => {
-    const headers = { 'x-zalando-request-uri': 'https://www.zalando.de/foo' }
+  it('merges headers with request uri with properties from nconf', async () => {
+    const headers = { 'x-zalando-request-uri': '/foo?q=bar' }
+
+    const sources = await resolveSources(headers, {})
+
+    expect(sources.bundles.src).toBe('http://localhost:3001')
+    expect(sources.bundles.path).toBe('/foo')
+  })
+
+  it('merges headers with request uri and host with properties from nconf', async () => {
+    const headers = {
+      'x-zalando-request-uri': '/foo?q=bar',
+      'x-zalando-request-host': 'www.zalando.de'
+    }
 
     const sources = await resolveSources(headers, {})
 
@@ -25,7 +37,7 @@ describe('sources-resolver', () => {
     require('request-promise-native').mockImplementation(() =>
       Promise.resolve({ sources: { bundles: { path: 'zalando.de/remote' } } }))
 
-    const headers = { 'x-zalando-request-uri': 'https://www.zalando.de/foo' }
+    const headers = { 'x-zalando-request-uri': '/foo' }
     const query = { sources: 'https://cdn.com/sources.json' }
 
     const sources = await resolveSources(headers, query)

--- a/packages/tessellate-fragment/test/actions/sources-resolver.test.js
+++ b/packages/tessellate-fragment/test/actions/sources-resolver.test.js
@@ -12,15 +12,6 @@ describe('sources-resolver', () => {
     expect(sources.bundles.src).toBe('http://localhost:3001')
   })
 
-  it('merges headers with request uri with properties from nconf', async () => {
-    const headers = { 'x-zalando-request-uri': '/foo?q=bar' }
-
-    const sources = await resolveSources(headers, {})
-
-    expect(sources.bundles.src).toBe('http://localhost:3001')
-    expect(sources.bundles.path).toBe('/foo')
-  })
-
   it('merges headers with request uri and host with properties from nconf', async () => {
     const headers = {
       'x-zalando-request-uri': '/foo?q=bar',
@@ -37,7 +28,10 @@ describe('sources-resolver', () => {
     require('request-promise-native').mockImplementation(() =>
       Promise.resolve({ sources: { bundles: { path: 'zalando.de/remote' } } }))
 
-    const headers = { 'x-zalando-request-uri': '/foo' }
+    const headers = {
+      'x-zalando-request-uri': '/foo',
+      'x-zalando-request-host': 'www.zalando.de'
+    }
     const query = { sources: 'https://cdn.com/sources.json' }
 
     const sources = await resolveSources(headers, query)


### PR DESCRIPTION
affects: tessellate-fragment

x-zalando-request-uri contains the path of an URL. We need to combine this path with

x-zalando-request-host (if available).

50