### PR TITLE
perf(fragment): added gzip compression for HTTP requests

### DIFF
--- a/packages/tessellate-fragment/src/actions/sources-resolver.js
+++ b/packages/tessellate-fragment/src/actions/sources-resolver.js
@@ -50,7 +50,11 @@ async function assignSourcePropertiesFromQuery(query: Object, sources: Object) {
   if (SOURCES_QUERY_PARAM in query) {
     const sourcesUrl = query[SOURCES_QUERY_PARAM];
     try {
-      const remoteSources = await request({ url: sourcesUrl, json: true });
+      const remoteSources = await request({
+        url: sourcesUrl,
+        json: true,
+        gzip: true
+      });
       merge(sources, remoteSources.sources);
     } catch (err) {
       throw new SourcesProblem(`Unable to load properties from ${sourcesUrl}`);

--- a/packages/tessellate-fragment/src/bundle-service.js
+++ b/packages/tessellate-fragment/src/bundle-service.js
@@ -42,6 +42,8 @@ async function fetchBundleFromHTTPSource(baseURL: string): Promise<Bundle> {
   const cssURL = `${baseURL}/index.css`;
 
   log.debug('Fetch bundle %s', jsURL);
-  const source = await request(jsURL);
+  const source = await request(jsURL, {
+    gzip: true
+  });
   return { source, links: { js: jsURL, css: cssURL } };
 }


### PR DESCRIPTION
affects: tessellate-fragment

Bundles and sources may be of significant size. Gzip compression reduces the size resulting in

shorter response times.

ISSUES CLOSED: #68