### PR TITLE
perf(request): added gzip compression for HTTP requests

### DIFF
--- a/packages/tessellate-request/lib/requests/default-request.js
+++ b/packages/tessellate-request/lib/requests/default-request.js
@@ -4,6 +4,8 @@ import request from 'request-promise-native';
 
 export default class DefaultRequest {
   async get(url: string): Object {
-    return await request(url);
+    return await request(url, {
+      gzip: true
+    });
   }
 }

--- a/packages/tessellate-request/lib/requests/file-backed-oauth-request.js
+++ b/packages/tessellate-request/lib/requests/file-backed-oauth-request.js
@@ -15,7 +15,8 @@ export default class JsonFileBackedOAuthRequest {
     return await request.get(url, {
       auth: {
         bearer: token
-      }
+      },
+      gzip: true
     });
   }
 }


### PR DESCRIPTION
affects: tessellate-request

Fetched content may be of significant size. Gzip compression reduces the size resulting in

shorter response times.

ISSUES CLOSED: #68