### PR TITLE
#83 ignore the `.idea` directory instead of its inner elements 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,26 +50,7 @@ Temporary Items
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
 # User-specific stuff:
-.idea/workspace.xml
-.idea/tasks.xml
-.idea/dictionaries
-.idea/vcs.xml
-.idea/jsLibraryMappings.xml
-
-# Sensitive or high-churn files:
-.idea/dataSources.ids
-.idea/dataSources.xml
-.idea/dataSources.local.xml
-.idea/sqlDataSources.xml
-.idea/dynamic.xml
-.idea/uiDesigner.xml
-
-# Gradle:
-.idea/gradle.xml
-.idea/libraries
-
-# Mongo Explorer plugin:
-.idea/mongoSettings.xml
+.idea
 
 ## File-based project format:
 *.iws


### PR DESCRIPTION
Closes #83 

The `.idea` directory is now completely ignored, instead of just ignoring _some_ of its inner file.

The complete directory needs to be ignored to ensure not polluting the repository with IDE files.